### PR TITLE
Minor improvements to the coloring and style

### DIFF
--- a/themes/Monokai-ST3-color-theme.json
+++ b/themes/Monokai-ST3-color-theme.json
@@ -13,55 +13,55 @@
 		"list.inactiveSelectionBackground": "#414339",
 		"list.hoverBackground": "#272822",
 		"list.dropBackground": "#414339",
-		"list.highlightForeground": "#f8f8f2",
+		"list.highlightForeground": "#F8F8F2",
 		"button.background": "#75715E",
 		"editor.background": "#272822",
-		"editor.foreground": "#f8f8f2",
-		"selection.background": "#ccccc7",
-		"editor.selectionBackground": "#49483e",
-		"editor.lineHighlightBackground": "#3e3d32",
-		"editorCursor.foreground": "#f8f8f0",
+		"editor.foreground": "#F8F8F2",
+		"selection.background": "#CCCCC7",
+		"editor.selectionBackground": "#49483E",
+		"editor.lineHighlightBackground": "#3E3D32",
+		"editorCursor.foreground": "#F8F8F0",
 		"editorWhitespace.foreground": "#464741",
 		"editorIndentGuide.background": "#464741",
-		"editorGroupHeader.tabsBackground": "#1e1f1c",
+		"editorGroupHeader.tabsBackground": "#1E1F1C",
 		"editorGroup.dropBackground": "#41433980",
 		"tab.inactiveBackground": "#414339",
-		"tab.border": "#1e1f1c",
-		"tab.activeBorder": "#ccccc7",
+		"tab.border": "#1E1F1C",
+		"tab.activeBorder": "#CCCCC7",
 		"tab.unfocusedActiveBorder": "#75715E",
-		"tab.inactiveForeground": "#ccccc7", // needs to be bright so it's readable when another editor group is focused
+		"tab.inactiveForeground": "#CCCCC7", // needs to be bright so it's readable when another editor group is focused
 		"widget.shadow": "#000000",
 		"progressBar.background": "#75715E",
 		"badge.background": "#75715E",
-		"badge.foreground": "#f8f8f2",
-		"editorLineNumber.foreground": "#90908a",
-		"panelTitle.activeForeground": "#f8f8f2",
+		"badge.foreground": "#F8F8F2",
+		"editorLineNumber.foreground": "#90908A",
+		"panelTitle.activeForeground": "#F8F8F2",
 		"panelTitle.activeBorder": "#75715E",
 		"panelTitle.inactiveForeground": "#75715E",
 		"panel.border": "#414339",
-		"titleBar.activeBackground": "#1e1f1c",
+		"titleBar.activeBackground": "#1E1F1C",
 		"statusBar.background": "#414339",		// return default status bar color
 		"statusBar.noFolderBackground": "#414339",
 		"statusBar.debuggingBackground": "#75715E",
 		"activityBar.background": "#272822",
-		"activityBar.foreground": "#f8f8f2",
+		"activityBar.foreground": "#F8F8F2",
 		"activityBar.dropBackground": "#414339",
-		"sideBar.background": "#1e1f1c",
+		"sideBar.background": "#1E1F1C",
 		"sideBarSectionHeader.background": "#272822",
 		"pickerGroup.foreground": "#75715E",
 		"input.background": "#414339",
 		"inputOption.activeBorder": "#75715E",
 		"focusBorder": "#75715E",
-		"editorWidget.background": "#1e1f1c",
-		"debugToolBar.background": "#1e1f1c",
+		"editorWidget.background": "#1E1F1C",
+		"debugToolBar.background": "#1E1F1C",
 		"diffEditor.insertedTextBackground": "#66852880", // middle of #272822 and #a6e22e
 		"diffEditor.removedTextBackground": "#90274A80", // middle of #272822 and #f92672
 		"inputValidation.errorBackground": "#90274A", // middle of #272822 and #f92672
-		"inputValidation.errorBorder": "#f92672",
+		"inputValidation.errorBorder": "#F92672",
 		"inputValidation.warningBackground": "#848528", // middle of #272822 and #e2e22e
-		"inputValidation.warningBorder": "#e2e22e",
+		"inputValidation.warningBorder": "#E2E22E",
 		"inputValidation.infoBackground": "#546190", // middle of #272822 and #819aff
-		"inputValidation.infoBorder": "#819aff",
+		"inputValidation.infoBorder": "#819AFF",
 		"editorHoverWidget.background": "#414339",
 		"editorHoverWidget.border": "#75715E",
 		"editorSuggestWidget.background": "#272822",
@@ -69,8 +69,8 @@
 		"editorGroup.border": "#414339",
 		"peekView.border": "#75715E",
 		"peekViewEditor.background": "#272822",
-		"peekViewResult.background": "#1e1f1c",
-		"peekViewTitle.background": "#1e1f1c",
+		"peekViewResult.background": "#1E1F1C",
+		"peekViewTitle.background": "#1E1F1C",
 		"peekViewResult.selectionBackground": "#414339",
 		"peekViewResult.matchHighlightBackground": "#75715E",
 		"peekViewEditor.matchHighlightBackground": "#75715E",
@@ -81,15 +81,15 @@
 		"terminal.ansiBlue": "#6A7EC8",
 		"terminal.ansiMagenta": "#8C6BC8",
 		"terminal.ansiCyan": "#56ADBC",
-		"terminal.ansiWhite": "#e3e3dd",
+		"terminal.ansiWhite": "#E3E3DD",
 		"terminal.ansiBrightBlack": "#666666",
-		"terminal.ansiBrightRed": "#f92672",
+		"terminal.ansiBrightRed": "#F92672",
 		"terminal.ansiBrightGreen": "#A6E22E",
-		"terminal.ansiBrightYellow": "#e2e22e", // hue shifted #A6E22E
-		"terminal.ansiBrightBlue": "#819aff", // hue shifted #AE81FF
+		"terminal.ansiBrightYellow": "#E2E22E", // hue shifted #A6E22E
+		"terminal.ansiBrightBlue": "#819AFF", // hue shifted #AE81FF
 		"terminal.ansiBrightMagenta": "#AE81FF",
 		"terminal.ansiBrightCyan": "#66D9EF",
-		"terminal.ansiBrightWhite": "#f8f8f2",
+		"terminal.ansiBrightWhite": "#F8F8F2",
 		"breadcrumb.foreground": "#75715E",
 
 	},
@@ -397,25 +397,25 @@
 		{
 			"scope": "token.info-token",
 			"settings": {
-				"foreground": "#6796e6"
+				"foreground": "#6796E6"
 			}
 		},
 		{
 			"scope": "token.warn-token",
 			"settings": {
-				"foreground": "#cd9731"
+				"foreground": "#CD9731"
 			}
 		},
 		{
 			"scope": "token.error-token",
 			"settings": {
-				"foreground": "#f44747"
+				"foreground": "#F44747"
 			}
 		},
 		{
 			"scope": "token.debug-token",
 			"settings": {
-				"foreground": "#b267e6"
+				"foreground": "#B267E6"
 			}
 		},
 		{
@@ -430,7 +430,7 @@
 			"name": "CSS fix - pseudo-class & pseudo-element",
 			"scope": "entity.other.attribute-name.pseudo-class.css, entity.other.attribute-name.pseudo-element.css",
 			"settings": {
-				"foreground": "#f8f8f2",
+				"foreground": "#F8F8F2",
 				"fontStyle": ""
 			}
 		},
@@ -468,21 +468,21 @@
 			"name": "Python class defined",
 			"scope": "entity.name.type.class.python",
 			"settings": {
-				"foreground": "#a6e22eff"
+				"foreground": "#A6E22E"
 			}
 		},
 		{
 			"name": "Python class inherit",
 			"scope": "meta.class.python support.type.python",
 			"settings": {
-				"foreground": "#a6e22eff"
+				"foreground": "#A6E22E"
 			}
 		},
 		{
 			"name": "Python function call",
 			"scope": "meta.function-call.generic.python",
 			"settings": {
-				"foreground": "#66d9efff"
+				"foreground": "#66D9EF"
 			}
 		},
 		{

--- a/themes/Monokai-ST3-color-theme.json
+++ b/themes/Monokai-ST3-color-theme.json
@@ -54,6 +54,8 @@
 		"focusBorder": "#75715E",
 		"editorError.foreground": "#00000000",
 		"editorError.border": "#90274A",
+		"editorWarning.foreground": "#00000000",
+		"editorWarning.border": "#848528",
 		"editorWidget.background": "#1E1F1C",
 		"debugToolBar.background": "#1E1F1C",
 		"diffEditor.insertedTextBackground": "#66852880", // middle of #272822 and #a6e22e

--- a/themes/Monokai-ST3-color-theme.json
+++ b/themes/Monokai-ST3-color-theme.json
@@ -173,7 +173,7 @@
 			"name": "User-defined constant",
 			"scope": "constant.character, constant.other",
 			"settings": {
-				"foreground": "#AE81FF"
+				"foreground": "#FFFFFF"
 			}
 		},
 		{
@@ -496,7 +496,7 @@
 			"name": "Python decorator call",
 			"scope": "entity.name.function.decorator.python",
 			"settings": {
-				"foreground": "#66D9EF"
+				"foreground": "#FFFFFF"
 			}
 		},
 	]

--- a/themes/Monokai-ST3-color-theme.json
+++ b/themes/Monokai-ST3-color-theme.json
@@ -52,6 +52,8 @@
 		"input.background": "#414339",
 		"inputOption.activeBorder": "#75715E",
 		"focusBorder": "#75715E",
+		"editorError.foreground": "#00000000",
+		"editorError.border": "#90274A",
 		"editorWidget.background": "#1E1F1C",
 		"debugToolBar.background": "#1E1F1C",
 		"diffEditor.insertedTextBackground": "#66852880", // middle of #272822 and #a6e22e


### PR DESCRIPTION
Hi! Thanks for your theme, I wasn't satisfied with the Monokai that is already built-in in VS Code. It lacks many colors and it's not really that helpful. While using yours, I figured out a couple of things that weren't exactly like in ST3, so here is a pull request with those:

* Python decorator names are now white: it's nice to have it in a neutral color like in ST3, so that they don't distract from the method signature that goes after it.
* USER_CONSTANTS are now white: they were purple before, and it looked a bit weird in white import statements.
* Error underlines were the default wavy ones: that aliased underline that is included in VS Code by default was a bit out of place, so I just replaced it with a straight double-underline with the more faded color that is a already included in the theme.

![Untitled-1](https://user-images.githubusercontent.com/9042837/101701388-1dca8000-3a7f-11eb-877d-13c11e98ce1f.png)

Aside from that, I just renamed every color hex code to uppercase and removed trailing "FF" at the alpha of some colors (since #123456FF is the same as #123456).

Hope you like it 😁